### PR TITLE
Update project to Visual Studio 2022

### DIFF
--- a/CpuSchedulingWinForms.sln
+++ b/CpuSchedulingWinForms.sln
@@ -1,8 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.902
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 2022
+VisualStudioVersion = 17.14.4
+MinimumVisualStudioVersion = 17.0.0
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CpuSchedulingWinForms", "CpuSchedulingWinForms\CpuSchedulingWinForms.csproj", "{6954F540-2148-4D2F-879A-BE82576B1083}"
 EndProject
 Global

--- a/CpuSchedulingWinForms/CpuSchedulingWinForms.csproj
+++ b/CpuSchedulingWinForms/CpuSchedulingWinForms.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/CpuSchedulingWinForms/Properties/Resources.Designer.cs
+++ b/CpuSchedulingWinForms/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace CpuSchedulingWinForms.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.14.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/CpuSchedulingWinForms/Properties/Settings.Designer.cs
+++ b/CpuSchedulingWinForms/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace CpuSchedulingWinForms.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.1.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.14.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));


### PR DESCRIPTION
## Summary
- update solution file for Visual Studio 2022 compatibility
- bump MSBuild ToolsVersion in csproj
- update designer generated code attributes to 17.14.0.0

## Testing
- `msbuild CpuSchedulingWinForms.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c58bd7e0832384bfdb406e49b548