### PR TITLE
Fix unresolved variable in scheduling form

### DIFF
--- a/CpuSchedulingWinForms/CpuSchedulerForm.cs
+++ b/CpuSchedulingWinForms/CpuSchedulerForm.cs
@@ -49,8 +49,8 @@ namespace CpuSchedulingWinForms
             if (txtProcess.Text != "")
             {
                 Algorithms.RunFirstComeFirstServe(txtProcess.Text);
-                int numberOfProcess = Int16.Parse(txtProcess.Text);
-                if (numberOfProcess <= 10)
+                int processCount = Int16.Parse(txtProcess.Text);
+                if (processCount <= 10)
                 {
                     this.progressBar1.Increment(4); //cpu progress bar
                     this.progressBar1.SetState(1);
@@ -99,8 +99,8 @@ namespace CpuSchedulingWinForms
             if (txtProcess.Text != "")
             {
                 Algorithms.RunShortestJobFirst(txtProcess.Text);
-                int numberOfProcess = Int16.Parse(txtProcess.Text);
-                if (numberOfProcess <= 10)
+                int processCount = Int16.Parse(txtProcess.Text);
+                if (processCount <= 10)
                 {
                     this.progressBar1.Increment(4); //cpu progress bar
                     this.progressBar1.SetState(1);
@@ -147,8 +147,8 @@ namespace CpuSchedulingWinForms
             if (txtProcess.Text != "")
             {
                 Algorithms.RunPriorityScheduling(txtProcess.Text);
-                int numberOfProcess = Int16.Parse(txtProcess.Text);
-                if (numberOfProcess <= 10)
+                int processCount = Int16.Parse(txtProcess.Text);
+                if (processCount <= 10)
                 {
                     this.progressBar1.Increment(4); //cpu progress bar
                     this.progressBar1.SetState(1);  //cpu color progress bar
@@ -244,8 +244,8 @@ namespace CpuSchedulingWinForms
             if (txtProcess.Text != "")
             {
                 Algorithms.RunRoundRobin(txtProcess.Text);
-                int numberOfProcess = Int16.Parse(txtProcess.Text);
-                if (numberOfProcess <= 10)
+                int processCount = Int16.Parse(txtProcess.Text);
+                if (processCount <= 10)
                 {
                     this.progressBar1.Increment(4); //cpu progress bar
                     this.progressBar1.SetState(1);  //cpu color progress bar


### PR DESCRIPTION
## Summary
- fix undefined `processCount` in CpuSchedulerForm by creating a local variable

## Testing
- `dotnet build CpuSchedulingWinForms.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842f35c99dc8323a6f7c1f0e817ea33